### PR TITLE
Remove obsolete code and update Discord link to actually be good 

### DIFF
--- a/src/components/Navbar/NavBar.vue
+++ b/src/components/Navbar/NavBar.vue
@@ -12,7 +12,7 @@
         >
       </li>
       <li>
-        <a href="https://discord.com/invite/S8zyJ84">Discord</a>
+        <a href="https://discord.gg/efp3f9q8RE">Discord</a>
       </li>
       <li>
         <a href="https://forms.gle/78DSWT9M4oCzHwFQA">Staff Application</a>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -144,17 +144,6 @@ p {
 #turnabout-link:hover {
   opacity: 0.8;
 }
-
-#objection-lol {
-  text-decoration: underline;
-  padding: 0px;
-  border-radius: 0px;
-  font-size: inherit;
-  background-color: inherit;
-}
-#objection-lol:hover {
-  opacity: 0.8;
-}
 @media only screen and (max-width: 1339px) {
   main {
     width: 100%;


### PR DESCRIPTION
There was some remaining code pertaining to the styling of the objection.lol partnership text, figured I'd remove it.
The link to our Discord, I came to find out, led to #3d-ripping instead of #general-chat, so I changed that because that's pretty big dumb in my opinion.
Also for the love of god make these changes live when you get the chance 🔫 